### PR TITLE
fix: ClassCastException in dump_permissions for non-permission commands

### DIFF
--- a/src/main/java/serverutils/command/CmdDumpPermissions.java
+++ b/src/main/java/serverutils/command/CmdDumpPermissions.java
@@ -150,6 +150,10 @@ public class CmdDumpPermissions extends CmdBase {
         commandList.add(Arrays.asList(EMPTY_ROW));
 
         for (ICommand command : CommandUtils.getAllCommands(sender)) {
+            if (!(command instanceof ICommandWithPermission)) {
+                continue;
+            }
+
             ICommandWithPermission cmd = (ICommandWithPermission) command;
             String node = cmd.serverutilities$getPermissionNode();
             DefaultPermissionLevel defaultPermissionLevel = DefaultPermissionHandler.INSTANCE


### PR DESCRIPTION
Somehow in GTNH 2.7.4 I got such exception when tried to use `dump_permissions` command:

```
[13:44:48] [Server thread/ERROR]: Couldn't process command: 'dump_permissions'
java.lang.ClassCastException: class com.matthewprenger.helpfixer.HelpFixer$1 cannot be cast to class serverutils.ranks.ICommandWithPermission (com.matthewprenger.helpfixer.HelpFixer$1 and serverutils.ranks.ICommandWithPermission are in unnamed module of loader 'Launch' @128d2484)
        at Launch//serverutils.command.CmdDumpPermissions.func_71515_b(CmdDumpPermissions.java:153) ~[CmdDumpPermissions.class:?]
        at Launch//net.minecraft.command.CommandHandler.func_71556_a(CommandHandler.java:94) [z.class:?]
        at Launch//net.minecraft.network.NetHandlerPlayServer.func_147361_d(NetHandlerPlayServer.java:739) [nh.class:?]
        at Launch//net.minecraft.network.NetHandlerPlayServer.func_147354_a(NetHandlerPlayServer.java:718) [nh.class:?]
        at Launch//net.minecraft.network.play.client.C01PacketChatMessage.func_148833_a(SourceFile:37) [ir.class:?]
        at Launch//net.minecraft.network.play.client.C01PacketChatMessage.func_148833_a(SourceFile:9) [ir.class:?]
        at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212) [ej.class:?]
        at Launch//net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165) [nc.class:?]
        at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659) [MinecraftServer.class:?]
        at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334) [lt.class:?]
        at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
        at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
        at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
```

This pull request adds check if command is ICommandWithPermission and only after that it will be casted, otherwise it simply will be ignored.